### PR TITLE
Fix GH Pages path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 ## Development
 
 Run `npm install` and `npm run dev`.
+
+The compiled build is located in the `docs` directory. This folder can be used
+directly with GitHub Pages, so you can preview the game in your browser without
+installing anything by opening `docs/index.html` or deploying it as a Pages
+site.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
-<html><script type="module" crossorigin src="/assets/index-D4-DPkDk.js"></script>
+<html><script type="module" crossorigin src="./assets/index-D4-DPkDk.js"></script>
 
 <body></body></html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 export default {
   root: 'src',
-  build: { outDir: '../docs' }
+  build: { outDir: '../docs' },
+  base: './'
 };


### PR DESCRIPTION
## Summary
- fix build config with a relative `base` so the docs work from subpaths
- document how to use the `docs` folder with GitHub Pages

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841b3b23454832da1adb2386fe88ead